### PR TITLE
Bump mainnet configuration version: v1.7.13.1-patch2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG ROSETTA_MAINNET_TAG=v0.4.4
 ARG ROSETTA_DOCKER_SCRIPTS_TAG=v0.2.7
 
 ARG CONFIG_DEVNET_TAG=D1.7.13.0-patch2
-ARG CONFIG_MAINNET_TAG=v1.7.13.0-patch2
+ARG CONFIG_MAINNET_TAG=v1.7.13.1-patch2
 
 # Install Python dependencies, necessary for "adjust_binary.py" and "adjust_observer_src.py"
 RUN apt-get update && apt-get -y install python3-pip && pip3 install toml --break-system-packages


### PR DESCRIPTION
New configuration tag: https://github.com/multiversx/mx-chain-mainnet-config/releases/tag/v1.7.13.1-patch2