### PR TITLE
Reference v1.8.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG ROSETTA_DEVNET_TAG=v0.6.1
 ARG ROSETTA_MAINNET_TAG=v0.6.1
 ARG ROSETTA_DOCKER_SCRIPTS_TAG=v0.2.7
 
-ARG CONFIG_DEVNET_TAG=D1.8.11.0
-ARG CONFIG_MAINNET_TAG=v1.8.11.1
+ARG CONFIG_DEVNET_TAG=D1.8.12.0
+ARG CONFIG_MAINNET_TAG=v1.8.12.0
 
 # Install Python dependencies, necessary for "adjust_binary.py" and "adjust_observer_src.py"
 RUN apt-get update && apt-get -y install python3-pip && pip3 install toml --break-system-packages


### PR DESCRIPTION
This release changes the Protocol sustainability rewards address to a multisig one for increased security.

Mainnet:
 - https://t.me/MultiversXValidatorsAnn/702
 - https://multiversx.com/release/release-spica-patch-4-v1-8-12
 - https://github.com/multiversx/mx-chain-mainnet-config/releases/tag/v1.8.12.0

Devnet:
 - https://t.me/MultiversXValidatorsAnn/701
 - https://github.com/multiversx/mx-chain-devnet-config/releases/tag/D1.8.12.0